### PR TITLE
Add Mapbox active navigation screen with mute button

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,7 @@ android {
         versionName "1.0"
 
         buildConfigField "String", "HERE_API_KEY", "\"${localProperties.getProperty('HERE_API_KEY', '')}\""
+        buildConfigField "String", "MAPBOX_TOKEN", "\"${localProperties.getProperty('MAPBOX_TOKEN', '')}\""
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -88,6 +89,16 @@ dependencies {
 
     // Phone number formatting
     implementation 'com.googlecode.libphonenumber:libphonenumber:8.13.26'
+
+    // Mapbox Maps SDK and Compose extension
+    implementation 'com.mapbox.maps:android:11.5.0'
+    implementation 'com.mapbox.extension:maps-compose:11.5.0'
+
+    // Mapbox Navigation Core SDK (provides MapboxNavigation, audioGuidance, route requests)
+    implementation 'com.mapbox.navigationcore:navigation:3.5.0'
+    implementation 'com.mapbox.navigationcore:android:3.5.0'
+    // Mapbox Navigation Voice UI (MapboxSpeechApi, MapboxVoiceInstructionsPlayer)
+    implementation 'com.mapbox.navigationcore:ui-voice:3.5.0'
 
 
     testImplementation 'junit:junit'

--- a/app/src/main/java/com/example/helloworld/ActiveNavigationScreen.kt
+++ b/app/src/main/java/com/example/helloworld/ActiveNavigationScreen.kt
@@ -1,0 +1,304 @@
+package com.example.helloworld
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.VolumeOff
+import androidx.compose.material.icons.outlined.VolumeUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.calmapps.directory.BuildConfig
+import com.example.helloworld.data.LocationRepository
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.maps.extension.compose.MapboxMap
+import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
+import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.core.directions.session.NavigationRouterCallback
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.core.trip.session.BannerInstructionsObserver
+import com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver
+import com.mapbox.navigation.ui.voice.api.MapboxSpeechApi
+import com.mapbox.navigation.ui.voice.api.MapboxVoiceInstructionsPlayer
+import com.mudita.mmd.components.divider.HorizontalDividerMMD
+import java.util.Locale
+
+/**
+ * Full-screen active navigation screen powered by Mapbox.
+ *
+ * Displays a Mapbox map with turn-by-turn navigation to [destLat]/[destLng].
+ * The bottom bar shows the current navigation instruction and a **mute button**
+ * that silences Mapbox voice guidance without stopping the navigation session.
+ *
+ * Prerequisites:
+ *  - Set `MAPBOX_TOKEN=pk.xxx...` in `local.properties` (public access token).
+ *  - Set `MAPBOX_DOWNLOADS_TOKEN=sk.xxx...` in `~/.gradle/gradle.properties`
+ *    (secret download token required to fetch Mapbox SDK artifacts).
+ *  - [MapboxNavigationApp] is initialised in [MyApplication.onCreate].
+ */
+@Composable
+fun ActiveNavigationScreen(
+    destLat: Double,
+    destLng: Double,
+    destName: String,
+    navController: NavController
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    // -------------------------------------------------------------------------
+    // State
+    // -------------------------------------------------------------------------
+
+    /** Whether Mapbox voice guidance is currently muted. */
+    var isMuted by remember { mutableStateOf(false) }
+
+    // rememberUpdatedState lets the VoiceInstructionsObserver lambda always
+    // read the latest isMuted value without the observer being recreated.
+    val currentIsMuted = rememberUpdatedState(isMuted)
+
+    /** Text of the most recent turn-by-turn banner instruction. */
+    var currentInstruction by remember { mutableStateOf("") }
+
+    /** Guard so we request a route only once per screen visit. */
+    var routeRequested by remember { mutableStateOf(false) }
+
+    // -------------------------------------------------------------------------
+    // Mapbox Navigation lifecycle
+    // -------------------------------------------------------------------------
+
+    // Attaching the lifecycle owner lets MapboxNavigationApp know when to
+    // create and destroy the underlying MapboxNavigation instance.
+    DisposableEffect(lifecycleOwner) {
+        MapboxNavigationApp.attach(lifecycleOwner)
+        onDispose {
+            MapboxNavigationApp.detach(lifecycleOwner)
+        }
+    }
+
+    val mapboxNavigation = remember {
+        runCatching { MapboxNavigationProvider.retrieve() }.getOrNull()
+    }
+
+    // -------------------------------------------------------------------------
+    // Location & route request
+    // -------------------------------------------------------------------------
+
+    val locationRepository = remember { LocationRepository(context) }
+    val location by locationRepository.location.collectAsState()
+
+    // Start location tracking and the navigation trip session.
+    DisposableEffect(mapboxNavigation) {
+        locationRepository.startLocationUpdates()
+        mapboxNavigation?.startTripSession()
+        onDispose {
+            locationRepository.stopLocationUpdates()
+            mapboxNavigation?.stopTripSession()
+        }
+    }
+
+    // Request a Mapbox route as soon as we have the first GPS fix.
+    // The routeRequested guard prevents duplicate calls on recomposition.
+    val nav = mapboxNavigation
+    val loc = location
+    if (nav != null && loc != null && !routeRequested) {
+        routeRequested = true
+        val origin = Point.fromLngLat(loc.longitude, loc.latitude)
+        val destination = Point.fromLngLat(destLng, destLat)
+
+        nav.requestRoutes(
+            RouteOptions.builder()
+                .applyDefaultNavigationOptions()
+                .coordinatesList(listOf(origin, destination))
+                .build(),
+            object : NavigationRouterCallback {
+                override fun onRoutesReady(
+                    routes: List<NavigationRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
+                    nav.setNavigationRoutes(routes)
+                }
+
+                override fun onFailure(
+                    reasons: List<RouterFailure>,
+                    routeOptions: RouteOptions
+                ) { /* Navigation continues in free-drive without a route */ }
+
+                override fun onCanceled(
+                    routeOptions: RouteOptions,
+                    routerOrigin: RouterOrigin
+                ) { }
+            }
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Banner instruction observer
+    // -------------------------------------------------------------------------
+
+    DisposableEffect(mapboxNavigation) {
+        val bannerObserver = BannerInstructionsObserver { bannerInstructions ->
+            currentInstruction = bannerInstructions.primary().text() ?: ""
+        }
+        mapboxNavigation?.registerBannerInstructionsObserver(bannerObserver)
+        onDispose {
+            mapboxNavigation?.unregisterBannerInstructionsObserver(bannerObserver)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Voice instructions observer
+    // -------------------------------------------------------------------------
+
+    // When isMuted is true the observer exits early so no speech is generated
+    // or played. rememberUpdatedState ensures we always read the latest value.
+    DisposableEffect(mapboxNavigation) {
+        val speechApi = MapboxSpeechApi(
+            context,
+            BuildConfig.MAPBOX_TOKEN,
+            Locale.getDefault().language
+        )
+        val voicePlayer = MapboxVoiceInstructionsPlayer(
+            context,
+            Locale.getDefault().language
+        )
+
+        val voiceObserver = VoiceInstructionsObserver { voiceInstructions ->
+            if (currentIsMuted.value) return@VoiceInstructionsObserver
+
+            speechApi.generate(voiceInstructions) { expected ->
+                expected.onValue { announcement ->
+                    voicePlayer.play(announcement) { /* no-op on finish */ }
+                }
+            }
+        }
+
+        mapboxNavigation?.registerVoiceInstructionsObserver(voiceObserver)
+
+        onDispose {
+            mapboxNavigation?.unregisterVoiceInstructionsObserver(voiceObserver)
+            speechApi.cancel()
+            voicePlayer.shutdown()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Map viewport — initially centred on the destination
+    // -------------------------------------------------------------------------
+
+    val mapViewportState = rememberMapViewportState {
+        setCameraOptions {
+            center(Point.fromLngLat(destLng, destLat))
+            zoom(13.0)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // UI
+    // -------------------------------------------------------------------------
+
+    Box(modifier = Modifier.fillMaxSize()) {
+
+        // Full-screen Mapbox map
+        MapboxMap(
+            modifier = Modifier.fillMaxSize(),
+            mapViewportState = mapViewportState
+        )
+
+        // Bottom navigation bar overlaid on the map
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surface)
+        ) {
+            HorizontalDividerMMD(
+                thickness = 2.dp,
+                color = MaterialTheme.colorScheme.outlineVariant
+            )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Back / stop navigation
+                IconButton(onClick = { navController.popBackStack() }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                        contentDescription = "Stop navigation"
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                // Current turn instruction, or destination name while route loads
+                Text(
+                    text = if (currentInstruction.isNotEmpty()) currentInstruction else destName,
+                    modifier = Modifier.weight(1f),
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                // ----------------------------------------------------------
+                // Mute button — the primary feature of this screen
+                // ----------------------------------------------------------
+                IconButton(
+                    onClick = {
+                        isMuted = !isMuted
+                        // Also inform the SDK's built-in audio guidance so
+                        // any SDK-level announcements are suppressed too.
+                        if (isMuted) {
+                            mapboxNavigation?.audioGuidance?.mute()
+                        } else {
+                            mapboxNavigation?.audioGuidance?.unmute()
+                        }
+                    }
+                ) {
+                    Icon(
+                        imageVector = if (isMuted) Icons.Outlined.VolumeOff
+                                      else         Icons.Outlined.VolumeUp,
+                        contentDescription = if (isMuted) "Unmute voice guidance"
+                                             else         "Mute voice guidance"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/helloworld/MainActivity.kt
+++ b/app/src/main/java/com/example/helloworld/MainActivity.kt
@@ -79,15 +79,22 @@ class MainActivity : ComponentActivity() {
                 val apiKey by mainViewModel.apiKey.collectAsState()
                 val focusRequester = remember { FocusRequester() }
 
+                val isNavigationScreen = navBackStackEntry?.destination?.route
+                    ?.startsWith("navigation") == true
+
                 Scaffold(
                     topBar = {
-                        DirectoryTopAppBar(
-                            navController = navController,
-                            navBackStackEntry = navBackStackEntry,
-                            searchViewModel = searchViewModel,
-                            apiKey = apiKey,
-                            focusRequester = focusRequester
-                        )
+                        // Hide the top bar on the active navigation screen so
+                        // the Mapbox map can fill the entire display height.
+                        if (!isNavigationScreen) {
+                            DirectoryTopAppBar(
+                                navController = navController,
+                                navBackStackEntry = navBackStackEntry,
+                                searchViewModel = searchViewModel,
+                                apiKey = apiKey,
+                                focusRequester = focusRequester
+                            )
+                        }
                     }
                 ) { paddingValues ->
                     NavHost(
@@ -96,6 +103,30 @@ class MainActivity : ComponentActivity() {
                         modifier = Modifier.padding(paddingValues),
                     ) {
                         composable("main") { MainScreen(navController, searchViewModel = searchViewModel) }
+                        composable(
+                            "navigation?lat={lat}&lng={lng}&name={name}",
+                            arguments = listOf(
+                                navArgument("lat") { type = NavType.FloatType },
+                                navArgument("lng") { type = NavType.FloatType },
+                                navArgument("name") {
+                                    type = NavType.StringType
+                                    defaultValue = ""
+                                }
+                            )
+                        ) { backStackEntry ->
+                            val lat = backStackEntry.arguments?.getFloat("lat")?.toDouble() ?: 0.0
+                            val lng = backStackEntry.arguments?.getFloat("lng")?.toDouble() ?: 0.0
+                            val name = URLDecoder.decode(
+                                backStackEntry.arguments?.getString("name") ?: "",
+                                StandardCharsets.UTF_8.toString()
+                            )
+                            ActiveNavigationScreen(
+                                destLat = lat,
+                                destLng = lng,
+                                destName = name,
+                                navController = navController
+                            )
+                        }
                         composable("settings") {
                             val scrollToLocationSettings =
                                 navController.previousBackStackEntry?.savedStateHandle?.get<Boolean>(
@@ -303,6 +334,9 @@ fun DirectoryTopAppBar(
                     }
 
                     "details/{poiName}/{poiAddress}/{poiCountry}/{poiPhone}/{poiDescription}/{poiHours}?poiWebsite={poiWebsite}&lat={lat}&lng={lng}" -> {
+                        val poiName = navBackStackEntry.arguments?.getString("poiName")
+                            ?.let { URLDecoder.decode(it.replace("%2F", "/"), StandardCharsets.UTF_8.toString()) }
+                            ?: ""
                         val poiWebsite = navBackStackEntry.arguments?.getString("poiWebsite")
                         val poiAddress = navBackStackEntry.arguments?.getString("poiAddress")
                         val poiCountry = navBackStackEntry.arguments?.getString("poiCountry")
@@ -340,6 +374,19 @@ fun DirectoryTopAppBar(
                                 poiAddress,
                                 StandardCharsets.UTF_8.toString()
                             )
+
+                            // Mapbox: launch the in-app ActiveNavigationScreen
+                            if (mapApp == MapApp.MAPBOX) {
+                                val encodedName = URLEncoder.encode(
+                                    poiName,
+                                    StandardCharsets.UTF_8.toString()
+                                )
+                                navController.navigate(
+                                    "navigation?lat=$lat&lng=$lng&name=$encodedName"
+                                )
+                                return@IconButton
+                            }
+
                             val clipboard =
                                 context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                             val clip = ClipData.newPlainText("address", decodedAddress)

--- a/app/src/main/java/com/example/helloworld/MyApplication.kt
+++ b/app/src/main/java/com/example/helloworld/MyApplication.kt
@@ -1,5 +1,24 @@
 package com.example.helloworld
 
 import android.app.Application
+import com.calmapps.directory.BuildConfig
+import com.mapbox.maps.MapboxOptions
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 
-class MyApplication : Application() 
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        if (BuildConfig.MAPBOX_TOKEN.isNotEmpty()) {
+            // Set the Maps SDK access token used by MapboxMap composable
+            MapboxOptions.accessToken = BuildConfig.MAPBOX_TOKEN
+            // Set up Navigation Core so MapboxNavigationProvider.retrieve() works
+            // anywhere in the app after a lifecycle owner attaches.
+            MapboxNavigationApp.setup(
+                NavigationOptions.Builder(this)
+                    .accessToken(BuildConfig.MAPBOX_TOKEN)
+                    .build()
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/helloworld/SettingsScreen.kt
+++ b/app/src/main/java/com/example/helloworld/SettingsScreen.kt
@@ -79,7 +79,7 @@ fun SettingsScreen(
         )
     }
     val locationSuggestions by viewModel.locationSuggestions.collectAsState()
-    val mapApp by userPreferencesRepository.mapApp.collectAsState(initial = MapApp.DEFAULT)
+    var mapApp by remember { mutableStateOf<MapApp?>(null) }
     var searchProvider by remember { mutableStateOf<SearchProvider?>(null) }
     val locationSettingsBringIntoViewRequester = remember { BringIntoViewRequester() }
     val suggestionsBringIntoViewRequester = remember { BringIntoViewRequester() }
@@ -102,6 +102,7 @@ fun SettingsScreen(
 
     LaunchedEffect(Unit) {
         searchProvider = userPreferencesRepository.searchProvider.first()
+        mapApp = userPreferencesRepository.mapApp.first()
     }
 
     LaunchedEffect(scrollToLocationSettings) {
@@ -135,6 +136,56 @@ fun SettingsScreen(
             .imePadding()
             .padding(vertical = 16.dp)
     ) {
+        item {
+            Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+                Text(text = "Navigation App", fontSize = 16.sp)
+                Spacer(modifier = Modifier.padding(4.dp))
+
+                listOf(
+                    MapApp.DEFAULT   to "System default",
+                    MapApp.GOOGLE_MAPS to "Google Maps",
+                    MapApp.TOMTOM    to "TomTom",
+                    MapApp.HERE_WEGO to "HERE WeGo",
+                    MapApp.MAPBOX    to "Mapbox (in-app)"
+                ).forEach { (app, label) ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp)
+                            .clickable {
+                                mapApp = app
+                                coroutineScope.launch {
+                                    userPreferencesRepository.saveMapApp(app)
+                                    snackbarHostState.showSnackbar("Navigation app set to $label")
+                                }
+                            }
+                    ) {
+                        RadioButtonMMD(
+                            selected = mapApp == app,
+                            onClick = null,
+                            modifier = Modifier.semantics { contentDescription = label }
+                        )
+                        Text(
+                            text = label,
+                            modifier = Modifier.padding(start = 8.dp)
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.padding(16.dp))
+
+                HorizontalDividerMMD(
+                    thickness = 1.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant
+                )
+            }
+        }
+
+        item {
+            Spacer(modifier = Modifier.padding(8.dp))
+        }
+
         item {
             Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
                 Text(text = "Data Provider", fontSize = 16.sp)

--- a/app/src/main/java/com/example/helloworld/data/MapApps.kt
+++ b/app/src/main/java/com/example/helloworld/data/MapApps.kt
@@ -4,7 +4,8 @@ enum class MapApp {
     DEFAULT,
     GOOGLE_MAPS,
     TOMTOM,
-    HERE_WEGO
+    HERE_WEGO,
+    MAPBOX
 }
 
 enum class SearchProvider {

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,21 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // Mapbox SDK artifacts — requires a secret download token.
+        // Add MAPBOX_DOWNLOADS_TOKEN=sk.xxx... to your ~/.gradle/gradle.properties or
+        // set it as an environment variable before building.
+        maven {
+            url 'https://api.mapbox.com/downloads/v2/releases/maven'
+            authentication {
+                basic(BasicAuthentication)
+            }
+            credentials {
+                username = "mapbox"
+                password = project.hasProperty('MAPBOX_DOWNLOADS_TOKEN')
+                    ? project.MAPBOX_DOWNLOADS_TOKEN
+                    : (System.getenv('MAPBOX_DOWNLOADS_TOKEN') ?: '')
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds in-app Mapbox turn-by-turn navigation with a **mute button** in the bottom bar to silence voice guidance without stopping the navigation session.

## What changed

### New screen — `ActiveNavigationScreen`
- Full-screen `MapboxMap` composable (Maps SDK v11 / maps-compose extension)
- Requests a route from the current GPS fix to the destination coordinates using Navigation Core SDK v3
- Registers a `BannerInstructionsObserver` to display the current turn instruction in the bottom bar
- Registers a `VoiceInstructionsObserver` + `MapboxSpeechApi` + `MapboxVoiceInstructionsPlayer` for text-to-speech
- **Bottom bar** (overlaid on the map): back button · instruction text · mute/unmute `IconButton`
  - Tapping mute toggles `isMuted` state and calls `mapboxNavigation.audioGuidance.mute()` / `.unmute()`
  - Icon switches between `VolumeUp` (unmuted) and `VolumeOff` (muted)
- The `TopAppBarMMD` is hidden on this screen so the map is truly full-screen

### Settings — Navigation App selection
- Added a **Navigation App** section to `SettingsScreen` with radio buttons for:
  `System default`, `Google Maps`, `TomTom`, `HERE WeGo`, **`Mapbox (in-app)`**
- Selecting **Mapbox** persists `MapApp.MAPBOX` via `UserPreferencesRepository`

### Routing — `MainActivity`
- New `navigation?lat={lat}&lng={lng}&name={name}` route registered in `NavHost`
- When `MapApp.MAPBOX` is selected, the Map icon on the POI details screen navigates to `ActiveNavigationScreen` instead of launching an external app

### Infrastructure
- `settings.gradle`: Mapbox maven repository with `BasicAuthentication`
  - Requires `MAPBOX_DOWNLOADS_TOKEN=sk.xxx...` in `~/.gradle/gradle.properties`
- `app/build.gradle`: `com.mapbox.maps:android:11.5.0`, `com.mapbox.extension:maps-compose:11.5.0`, `com.mapbox.navigationcore:navigation:3.5.0`, `com.mapbox.navigationcore:android:3.5.0`, `com.mapbox.navigationcore:ui-voice:3.5.0`; `MAPBOX_TOKEN` `BuildConfig` field from `local.properties`
- `MyApplication`: `MapboxOptions.accessToken` and `MapboxNavigationApp.setup()` initialised on app start
- `data/MapApps.kt`: added `MAPBOX` to the `MapApp` enum

## Setup required

Add the following to your `local.properties`:
```
MAPBOX_TOKEN=pk.your_public_access_token
```

Add the following to `~/.gradle/gradle.properties` (or CI environment):
```
MAPBOX_DOWNLOADS_TOKEN=sk.your_secret_download_token
```

Both tokens are available from [account.mapbox.com](https://account.mapbox.com).

---
_This PR was generated with [Oz](https://www.warp.dev/oz)._
